### PR TITLE
Bug fix on the calculus of the group footer band height.

### DIFF
--- a/src/main/java/ar/com/fdvs/dj/core/layout/AbstractLayoutManager.java
+++ b/src/main/java/ar/com/fdvs/dj/core/layout/AbstractLayoutManager.java
@@ -613,7 +613,7 @@ public abstract class AbstractLayoutManager implements LayoutManager {
 					
 				}
 				for (JRBand footerBand : (List<JRBand>)footerSection.getBandsList()) {
-					setBandFinalHeight((JRDesignBand) footerBand,djGroup.getFooterHeight(), djGroup.isFitHeaderHeightToContent());
+					setBandFinalHeight((JRDesignBand) footerBand,djGroup.getFooterHeight(), djGroup.isFitFooterHeightToContent());
 					
 				}
 			} else {


### PR DESCRIPTION
Bug fix on the calculus of the group footer band height (was using isFitHeaderHeightToContent instead of isFitFooterHeightToContent).
