### PR TITLE
Update commons-beanutils (fix for CVE-2014-0114)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ar.com.fdvs</groupId>
     <artifactId>DynamicJasper</artifactId>
-    <version>5.1.2</version>
+    <version>5.1.1</version>
     <name>DynamicJasper</name>
     <packaging>jar</packaging>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ar.com.fdvs</groupId>
     <artifactId>DynamicJasper</artifactId>
-    <version>5.1.1</version>
+    <version>5.1.2</version>
     <name>DynamicJasper</name>
     <packaging>jar</packaging>
     <description>
@@ -339,7 +339,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.7.0</version>
+            <version>1.9.3</version>
         </dependency>
         <dependency>
             <groupId>opensymphony</groupId>


### PR DESCRIPTION
commons-beanutils 1.7.0 contains a vulnerability which may allow a user to execute arbitrary code. (CVE-2014-0114). Regardless if DynamicJasper's usage of beanutils is vulnerable there seems to be no reason to continue using the outdated dependency. Everything compiles and passes unit tests with the updated dependency.