### PR TITLE
Fixes CVE-2020-11988

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,7 +302,7 @@
         <dependency>
             <groupId>net.sf.jasperreports</groupId>
             <artifactId>jasperreports</artifactId>
-            <version>[6.8.0, 6.17.0]</version>
+            <version>[6.8.0, 6.18.1]</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-collections</groupId>
@@ -382,7 +382,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>xmlgraphics-commons</artifactId>
-            <version>1.5</version>
+            <version>2.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This commit updates org.apache.xmlgraphics:xmlgraphics-commons to version 2.6
to adress the open CVE.  
See https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEXMLGRAPHICS-1079038 for more information about it.  
It alo updates the supported jasperreports version to 6.18.1 so we can enjoy the bugfixes and improvements.