### PR TITLE
Update deprecated code in latest JasperReports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ar.com.fdvs</groupId>
     <artifactId>DynamicJasper</artifactId>
-    <version>5.3.6</version>
+    <version>5.3.7-SNAPSHOT</version>
     <name>DynamicJasper</name>
     <packaging>jar</packaging>
     <description>
@@ -328,7 +328,7 @@
         <dependency>
             <groupId>net.sf.jasperreports</groupId>
             <artifactId>jasperreports</artifactId>
-            <version>[6.8.0, 6.19.1]</version>
+            <version>[6.11.0, 6.20.0]</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-collections</groupId>

--- a/src/main/java/ar/com/fdvs/dj/core/layout/AbstractLayoutManager.java
+++ b/src/main/java/ar/com/fdvs/dj/core/layout/AbstractLayoutManager.java
@@ -632,14 +632,14 @@ public abstract class AbstractLayoutManager implements LayoutManager {
         designElemen.setStyle(jrstyle);
         if (designElemen instanceof JRDesignTextElement) {
             JRDesignTextElement textField = (JRDesignTextElement) designElemen;
-            if (style.getStreching() != null)
-                textField.setStretchType(StretchTypeEnum.getByValue(style.getStreching().getValue()));
+            if (style.getStretchType() != null)
+                textField.setStretchType(style.getStretchType());
             textField.setPositionType(PositionTypeEnum.FLOAT);
 
         }
         if (designElemen instanceof JRDesignTextField) {
             JRDesignTextField textField = (JRDesignTextField) designElemen;
-            textField.setStretchWithOverflow(style.isStretchWithOverflow());
+            textField.setTextAdjust(style.getTextAdjust());
 
             if (!textField.isBlankWhenNull() && style.isBlankWhenNull()) //TODO Re check if this condition is ok
                 textField.setBlankWhenNull(true);
@@ -647,7 +647,7 @@ public abstract class AbstractLayoutManager implements LayoutManager {
 
         if (designElemen instanceof JRDesignGraphicElement) {
             JRDesignGraphicElement graphicElement = (JRDesignGraphicElement) designElemen;
-            graphicElement.setStretchType(StretchTypeEnum.getByValue(style.getStreching().getValue()));
+            graphicElement.setStretchType(style.getStretchType());
             graphicElement.setPositionType(PositionTypeEnum.FLOAT);
         }
     }

--- a/src/main/java/ar/com/fdvs/dj/domain/Style.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/Style.java
@@ -80,13 +80,9 @@ public class Style implements Serializable, Cloneable {
 
 	private Transparency transparency = Transparency.TRANSPARENT;
 
-	@Deprecated
-    private VerticalAlign verticalAlign = VerticalAlign.BOTTOM;
-	private VerticalTextAlign verticalTextAlign = VerticalTextAlign.BOTTOM;
-	private VerticalImageAlign verticalImageAlign = VerticalImageAlign.BOTTOM;
+    private VerticalTextAlign verticalTextAlign = VerticalTextAlign.BOTTOM;
+    private VerticalImageAlign verticalImageAlign = VerticalImageAlign.BOTTOM;
 
-	@Deprecated
-    private HorizontalAlign horizontalAlign = null;
     private HorizontalTextAlign horizontalTextAlign = HorizontalTextAlign.LEFT;
     private HorizontalImageAlign horizontalImageAlign = HorizontalImageAlign.LEFT;
 
@@ -191,12 +187,36 @@ public class Style implements Serializable, Cloneable {
 		else this.font = null;
 	}
 
-	public HorizontalAlign getHorizontalAlign() {
-		return horizontalAlign;
+	/**
+	 * @deprecated Use #Style.setHorizontalTextAlign(...) and #Style.setHorizontalImageAlign(...) instead
+	 * @param horizontalAlign
+	 */
+	@Deprecated
+	public void setHorizontalAlign(HorizontalAlign horizontalAlign) {
+		if (horizontalAlign == null) {
+			horizontalTextAlign = null;
+			horizontalImageAlign = null;
+		}
+		else {
+			horizontalTextAlign = HorizontalTextAlign.fromLegacy(horizontalAlign.getValue());
+			horizontalImageAlign = HorizontalImageAlign.fromLegacy(horizontalAlign.getValue());
+		}
 	}
 
-	public void setHorizontalAlign(HorizontalAlign horizontalAlign) {
-		this.horizontalAlign = horizontalAlign;
+	public HorizontalTextAlign getHorizontalTextAlign() {
+            return horizontalTextAlign;
+	}
+
+	public void setHorizontalTextAlign(HorizontalTextAlign horizontalTextAlign) {
+		this.horizontalTextAlign = horizontalTextAlign;
+	}
+
+	public HorizontalImageAlign getHorizontalImageAlign() {
+            return horizontalImageAlign;
+	}
+
+	public void setHorizontalImageAlign(HorizontalImageAlign horizontalImageAlign) {
+		this.horizontalImageAlign = horizontalImageAlign;
 	}
 
 	public Integer getPadding() {
@@ -250,12 +270,36 @@ public class Style implements Serializable, Cloneable {
 			this.setTransparency(Transparency.OPAQUE);
 	}
 
-	public VerticalAlign getVerticalAlign() {
-		return verticalAlign;
+	/**
+	 * @deprecated Use #Style.setVerticalTextAlign(...) and #Style.setVerticalImageAlign(...) instead
+	 * @param verticalAlign
+	 */
+	@Deprecated
+	public void setVerticalAlign(VerticalAlign verticalAlign) {
+		if (verticalAlign == null) {
+			verticalTextAlign = null;
+			verticalImageAlign = null;
+		}
+		else {
+			verticalTextAlign = VerticalTextAlign.fromLegacy(verticalAlign.getValue());
+			verticalImageAlign = VerticalImageAlign.fromLegacy(verticalAlign.getValue());
+		}
 	}
 
-	public void setVerticalAlign(VerticalAlign verticalAlign) {
-		this.verticalAlign = verticalAlign;
+	public void setVerticalTextAlign(VerticalTextAlign verticalTextAlign) {
+		this.verticalTextAlign = verticalTextAlign;
+	}
+
+	public VerticalTextAlign getVerticalTextAlign() {
+		return verticalTextAlign;
+	}
+
+	public void setVerticalImageAlign(VerticalImageAlign verticalImageAlign) {
+		this.verticalImageAlign = verticalImageAlign;
+	}
+
+	public VerticalImageAlign getVerticalImageAlign() {
+		return verticalImageAlign;
 	}
 
 	public JRDesignConditionalStyle transformAsConditinalStyle() {
@@ -302,33 +346,21 @@ public class Style implements Serializable, Cloneable {
 
 
 		//horizontal TEXT Aligns
-		if (getHorizontalAlign() == null && getHorizontalTextAlign() != null) {
-			transformedStyle.setHorizontalTextAlign(HorizontalTextAlignEnum.getByName(getHorizontalTextAlign().getName()));
-		} else if (getHorizontalAlign() != null) {
-			HorizontalTextAlign horizontalTextAlign = HorizontalTextAlign.fromLegacy(getHorizontalAlign().getValue());
+		if (horizontalTextAlign != null) {
 			transformedStyle.setHorizontalTextAlign(HorizontalTextAlignEnum.getByName(horizontalTextAlign.getName()));
 		}
 
 		//Vertical TEXT aligns
-		if (getVerticalAlign() == null && getVerticalTextAlign() != null){
-			transformedStyle.setVerticalTextAlign(VerticalTextAlignEnum.getByName(getVerticalTextAlign().getName()));
-		} else if (getVerticalAlign() != null) {
-			VerticalTextAlign verticalTextAlign = VerticalTextAlign.fromLegacy(getVerticalAlign().getValue());
+		if (verticalTextAlign != null){
 			transformedStyle.setVerticalTextAlign(VerticalTextAlignEnum.getByName(verticalTextAlign.getName()));
 		}
 
 		//Horizontal Image align
-		if (getHorizontalAlign() == null && getHorizontalImageAlign() != null) {
-			transformedStyle.setHorizontalImageAlign(HorizontalImageAlignEnum.getByName(getHorizontalImageAlign().getName()));
-		} else if (getHorizontalAlign() != null) {
-			HorizontalImageAlign horizontalTextAlign = HorizontalImageAlign.fromLegacy(getHorizontalAlign().getValue());
-			transformedStyle.setHorizontalImageAlign(HorizontalImageAlignEnum.getByName(horizontalTextAlign.getName()));
+		if (horizontalImageAlign != null) {
+			transformedStyle.setHorizontalImageAlign(HorizontalImageAlignEnum.getByName(horizontalImageAlign.getName()));
 		}
 		//Vertical Image align
-		if (getVerticalAlign() == null && getVerticalImageAlign() != null){
-			transformedStyle.setVerticalImageAlign(VerticalImageAlignEnum.getByName(getVerticalImageAlign().getName()));
-		} else if (getVerticalAlign() != null) {
-			VerticalImageAlign verticalImageAlign = VerticalImageAlign.fromLegacy(getVerticalAlign().getValue());
+		if (verticalImageAlign != null){
 			transformedStyle.setVerticalImageAlign(VerticalImageAlignEnum.getByName(verticalImageAlign.getName()));
 		}
 
@@ -403,7 +435,7 @@ public class Style implements Serializable, Cloneable {
 	}
 
     /**
-     * use #Style.getBorder().getColor() instead
+     * @deprecated use #Style.getBorder().getColor() instead
      * @return
      */
     @Deprecated
@@ -414,7 +446,7 @@ public class Style implements Serializable, Cloneable {
 	}
 
     /**
-     * Use #Style.setBorder(...) instead
+     * @deprecated Use #Style.setBorder(...) instead
      * @param borderColor
      */
     @Deprecated
@@ -501,21 +533,5 @@ public class Style implements Serializable, Cloneable {
 		Style style = (Style) super.clone();
 		style.setFont(this.font);
 		return style;
-	}
-
-	public HorizontalTextAlign getHorizontalTextAlign() {
-		return horizontalTextAlign;
-	}
-
-	public VerticalTextAlign getVerticalTextAlign() {
-		return verticalTextAlign;
-	}
-
-	public HorizontalImageAlign getHorizontalImageAlign() {
-		return horizontalImageAlign;
-	}
-
-	public VerticalImageAlign getVerticalImageAlign() {
-		return verticalImageAlign;
 	}
 }

--- a/src/main/java/ar/com/fdvs/dj/domain/Style.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/Style.java
@@ -88,9 +88,10 @@ public class Style implements Serializable, Cloneable {
 
     private Rotation rotation = Rotation.NONE;
 
-    private Stretching streching = Stretching.RELATIVE_TO_TALLEST_OBJECT;
+    private StretchTypeEnum stretchType = StretchTypeEnum.ELEMENT_GROUP_BOTTOM;
 
-    private boolean stretchWithOverflow = true;
+	private TextAdjustEnum textAdjust = TextAdjustEnum.STRETCH_HEIGHT;
+
     private boolean blankWhenNull = true;
 
     private String pattern;
@@ -133,8 +134,9 @@ public class Style implements Serializable, Cloneable {
 		style.setVerticalAlign(null);
 		style.setHorizontalAlign(null);
 		style.setRotation(null);
-		style.setStreching(null);
-
+		style.setStretchType(null);
+		style.SetTextAdjust(null);
+		
 		return style;
 
 	}
@@ -227,20 +229,75 @@ public class Style implements Serializable, Cloneable {
 		this.padding = padding;
 	}
 
+	/**
+	 * @deprecated Use {@link #getStretchType(StretchTypeEnum)}
+	 * @return
+	 */
+	@Deprecated
 	public Stretching getStreching() {
-		return streching;
+		if (StretchTypeEnum.NO_STRETCH.equals(stretchType)) {
+			return Stretching.NO_STRETCH;
+		}
+		else if (StretchTypeEnum.RELATIVE_TO_TALLEST_OBJECT.equals(stretchType)) {
+			return Stretching.RELATIVE_TO_TALLEST_OBJECT;
+		}
+		else if (StretchTypeEnum.RELATIVE_TO_BAND_HEIGHT.equals(stretchType)) {
+			return Stretching.RELATIVE_TO_BAND_HEIGHT;
+		}
+		return null;
 	}
 
+	/**
+	 * @deprecated Use {@link #setStretchType(StretchTypeEnum)}
+	 * @param streching
+	 */
+	@Deprecated
 	public void setStreching(Stretching streching) {
-		this.streching = streching;
+		if (Stretching.NO_STRETCH.equals(streching)) {
+			stretchType = StretchTypeEnum.NO_STRETCH;
+		}
+		else if (Stretching.RELATIVE_TO_TALLEST_OBJECT.equals(streching)) {
+			stretchType = StretchTypeEnum.RELATIVE_TO_TALLEST_OBJECT;
+		}
+		else if (Stretching.RELATIVE_TO_BAND_HEIGHT.equals(streching)) {
+			stretchType = StretchTypeEnum.RELATIVE_TO_BAND_HEIGHT;
+		}
 	}
 
+	public StretchTypeEnum getStretchType() {
+		return stretchType;
+	}
+
+	public void setStretchType(StretchTypeEnum stretchType) {
+		this.stretchType = stretchType;
+	}
+
+	/**
+	 * @deprecated Use {@link #getTextAdjust()}
+	 * @return
+	 */
+	@Deprecated
 	public boolean isStretchWithOverflow() {
-		return stretchWithOverflow;
+		return TextAdjustEnum.STRETCH_HEIGHT.equals(textAdjust);
 	}
 
+	/**
+	 * @deprecated Use {@link #SetTextAdjust(TextAdjustEnum)}
+	 * @param stretchWithOverflow
+	 */
+    @Deprecated
 	public void setStretchWithOverflow(boolean stretchWithOverflow) {
-		this.stretchWithOverflow = stretchWithOverflow;
+		if (stretchWithOverflow) {
+			this.textAdjust = TextAdjustEnum.STRETCH_HEIGHT;
+		}		
+	}
+
+	public TextAdjustEnum getTextAdjust() {
+		return textAdjust;
+	}
+
+	public void SetTextAdjust(TextAdjustEnum textAdjust) {
+		this.textAdjust = textAdjust;
 	}
 
 	public Color getTextColor() {

--- a/src/main/java/ar/com/fdvs/dj/domain/builders/StyleBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/builders/StyleBuilder.java
@@ -41,6 +41,8 @@ import ar.com.fdvs.dj.domain.constants.Transparency;
 import ar.com.fdvs.dj.domain.constants.VerticalAlign;
 import ar.com.fdvs.dj.domain.constants.VerticalImageAlign;
 import ar.com.fdvs.dj.domain.constants.VerticalTextAlign;
+import net.sf.jasperreports.engine.type.StretchTypeEnum;
+import net.sf.jasperreports.engine.type.TextAdjustEnum;
 
 import java.awt.Color;
 
@@ -141,8 +143,19 @@ public class StyleBuilder {
 		return this;
 	}
 
+	/**
+	 * @deprecated Use {@link #setStretchType(StretchTypeEnum)}
+	 * @param streching
+	 * @return
+	 */
+	@Deprecated
 	public StyleBuilder setStretching(Stretching streching){
 		style.setStreching(streching);
+		return this;
+	}
+
+	public StyleBuilder setStretchType(StretchTypeEnum stretchType) {
+		style.setStretchType(stretchType);
 		return this;
 	}
 
@@ -245,11 +258,20 @@ public class StyleBuilder {
 		return this;
 	}
 	
+	/**
+	 * @deprecated Use {@link #setTextAdjust(TextAdjustEnum)}
+	 * @param stretchWithOverflow
+	 * @return
+	 */
+	@Deprecated
 	public StyleBuilder setStretchWithOverflow(boolean stretchWithOverflow) {
 		style.setStretchWithOverflow(stretchWithOverflow);
 		return this;
 	}
 	
-
+	public StyleBuilder setTextAdjust(TextAdjustEnum textAdjust) {
+		style.SetTextAdjust(textAdjust);
+		return this;
+	}
 
 }

--- a/src/main/java/ar/com/fdvs/dj/domain/builders/StyleBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/builders/StyleBuilder.java
@@ -33,10 +33,14 @@ import ar.com.fdvs.dj.domain.Style;
 import ar.com.fdvs.dj.domain.constants.Border;
 import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.constants.HorizontalAlign;
+import ar.com.fdvs.dj.domain.constants.HorizontalImageAlign;
+import ar.com.fdvs.dj.domain.constants.HorizontalTextAlign;
 import ar.com.fdvs.dj.domain.constants.Rotation;
 import ar.com.fdvs.dj.domain.constants.Stretching;
 import ar.com.fdvs.dj.domain.constants.Transparency;
 import ar.com.fdvs.dj.domain.constants.VerticalAlign;
+import ar.com.fdvs.dj.domain.constants.VerticalImageAlign;
+import ar.com.fdvs.dj.domain.constants.VerticalTextAlign;
 
 import java.awt.Color;
 
@@ -97,13 +101,43 @@ public class StyleBuilder {
 		return this;
 	}
 
+	/**
+	 * @deprecated  Use #StyleBuilder.setHorizontalTextAlign(...) and #StyleBuilder.setHorizontalImageAlign(...) instead
+	 * @param horizontalAlign
+	 */
+	@Deprecated
 	public StyleBuilder setHorizontalAlign(HorizontalAlign horizontalAlign){
 		style.setHorizontalAlign(horizontalAlign);
 		return this;
 	}
 
+	public StyleBuilder setHorizontalTextAlign(HorizontalTextAlign horizontalTextAlign){
+		style.setHorizontalTextAlign(horizontalTextAlign);
+		return this;
+	}
+
+	public StyleBuilder setHorizontalImageAlign(HorizontalImageAlign horizontalImageAlign){
+		style.setHorizontalImageAlign(horizontalImageAlign);
+		return this;
+	}
+
+	/**
+     * @deprecated  Use #StyleBuilder.setVerticalTextAlign(...) and #StyleBuilder.setVerticalImageAlign(...) instead
+	 * @param verticalAlign
+	 */
+	@Deprecated
 	public StyleBuilder setVerticalAlign(VerticalAlign verticalAlign){
 		style.setVerticalAlign(verticalAlign);
+		return this;
+	}
+
+	public StyleBuilder setVerticalTextAlign(VerticalTextAlign verticalTextAlign){
+		style.setVerticalTextAlign(verticalTextAlign);
+		return this;
+	}
+
+	public StyleBuilder setVerticalImageAlign(VerticalImageAlign verticalImageAlign){
+		style.setVerticalImageAlign(verticalImageAlign);
 		return this;
 	}
 
@@ -175,6 +209,7 @@ public class StyleBuilder {
 	 * @param paddingBotton
 	 * @return
 	 */
+	@Deprecated
 	public StyleBuilder setPaddingBotton(Integer paddingBotton) {
 		return setPaddingBottom(paddingBotton);
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJAreaChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJAreaChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -397,11 +397,11 @@ public class DJAreaChartBuilder extends AbstractChartBuilder<DJAreaChartBuilder>
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJAreaChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJAreaChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJBar3DChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJBar3DChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.Color;
 import java.util.List;
@@ -397,11 +397,11 @@ public class DJBar3DChartBuilder extends AbstractChartBuilder<DJBar3DChartBuilde
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJBar3DChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJBar3DChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJBarChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJBarChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -397,11 +397,11 @@ public class DJBarChartBuilder extends AbstractChartBuilder<DJBarChartBuilder> {
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJBarChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJBarChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJLineChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJLineChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -396,11 +396,11 @@ public class DJLineChartBuilder extends AbstractChartBuilder<DJLineChartBuilder>
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJLineChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJLineChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJScatterChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJScatterChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -400,11 +400,11 @@ public class DJScatterChartBuilder extends AbstractChartBuilder<DJScatterChartBu
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJScatterChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJScatterChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJTimeSeriesChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJTimeSeriesChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -411,11 +411,11 @@ public class DJTimeSeriesChartBuilder extends AbstractChartBuilder<DJTimeSeriesC
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJTimeSeriesChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJTimeSeriesChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJXYAreaChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJXYAreaChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -400,11 +400,11 @@ public class DJXYAreaChartBuilder extends AbstractChartBuilder<DJXYAreaChartBuil
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJXYAreaChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJXYAreaChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJXYBarChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJXYBarChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -400,11 +400,11 @@ public class DJXYBarChartBuilder extends AbstractChartBuilder<DJXYBarChartBuilde
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJXYBarChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJXYBarChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJXYLineChartBuilder.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/builder/DJXYLineChartBuilder.java
@@ -39,7 +39,7 @@ import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
 import ar.com.fdvs.dj.domain.hyperlink.LiteralExpression;
-import org.jfree.chart.plot.PlotOrientation;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 
 import java.awt.*;
 import java.util.List;
@@ -400,11 +400,11 @@ public class DJXYLineChartBuilder extends AbstractChartBuilder<DJXYLineChartBuil
 	}
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public DJXYLineChartBuilder setOrientation(PlotOrientation orientation) {
+	public DJXYLineChartBuilder setOrientation(PlotOrientationEnum orientation) {
 		getPlot().setOrientation(orientation);
 		return this;
 	}

--- a/src/main/java/ar/com/fdvs/dj/domain/chart/plot/AbstractPlot.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/chart/plot/AbstractPlot.java
@@ -32,9 +32,9 @@ package ar.com.fdvs.dj.domain.chart.plot;
 import ar.com.fdvs.dj.domain.DJBaseElement;
 import ar.com.fdvs.dj.domain.DynamicJasperDesign;
 import ar.com.fdvs.dj.domain.entities.Entity;
+import net.sf.jasperreports.charts.type.PlotOrientationEnum;
 import net.sf.jasperreports.engine.JRChartPlot;
 import net.sf.jasperreports.engine.base.JRBaseChartPlot;
-import org.jfree.chart.plot.PlotOrientation;
 
 import java.awt.Color;
 import java.util.ArrayList;
@@ -46,24 +46,24 @@ public abstract class AbstractPlot extends DJBaseElement {
 	private static final long serialVersionUID = Entity.SERIAL_VERSION_UID;
 	
 	private Double labelRotation;
-	private PlotOrientation orientation;
+	private PlotOrientationEnum orientation;
 	private final List<Color> seriesColors = new ArrayList<Color>();
 
 	/**
-	 * Sets the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Sets the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @param orientation the plot orientation
 	 **/
-	public void setOrientation(PlotOrientation orientation) {
+	public void setOrientation(PlotOrientationEnum orientation) {
 		this.orientation = orientation;
 	}
 
 	/**
-	 * Returns the plot orientation (PlotOrientation.HORIZONTAL or PlotOrientation.VERTICAL).
+	 * Returns the plot orientation (PlotOrientationEnum.HORIZONTAL or PlotOrientationEnum.VERTICAL).
 	 *
 	 * @return	the plot orientation
 	 **/
-	public PlotOrientation getOrientation() {
+	public PlotOrientationEnum getOrientation() {
 		return orientation;
 	}
 
@@ -128,7 +128,7 @@ public abstract class AbstractPlot extends DJBaseElement {
 		if (getLabelRotation() != null)
 			plot.setLabelRotation(getLabelRotation());
 		if (orientation != null)
-			plot.setOrientation(PlotOrientationEnum.getByValue(orientation));
+			plot.setOrientation(orientation);
 		List<JRBaseChartPlot.JRSeriesColor> colors = new ArrayList<JRBaseChartPlot.JRSeriesColor>();
 		int i = 1;
 		for (Color color : seriesColors) {

--- a/src/main/java/ar/com/fdvs/dj/domain/constants/Stretching.java
+++ b/src/main/java/ar/com/fdvs/dj/domain/constants/Stretching.java
@@ -29,6 +29,7 @@
 
 package ar.com.fdvs.dj.domain.constants;
 
+@Deprecated
 public class Stretching  extends BaseDomainConstant {
 
 	private static final long serialVersionUID = 1L;

--- a/src/test/java/ar/com/fdvs/dj/test/MultiLineTitleReportTest.java
+++ b/src/test/java/ar/com/fdvs/dj/test/MultiLineTitleReportTest.java
@@ -32,13 +32,15 @@ package ar.com.fdvs.dj.test;
 
 import java.util.Date;
 
+import net.sf.jasperreports.engine.type.StretchTypeEnum;
+import net.sf.jasperreports.engine.type.TextAdjustEnum;
 import net.sf.jasperreports.view.JasperDesignViewer;
 import net.sf.jasperreports.view.JasperViewer;
 import ar.com.fdvs.dj.domain.DynamicReport;
 import ar.com.fdvs.dj.domain.Style;
 import ar.com.fdvs.dj.domain.builders.FastReportBuilder;
-import ar.com.fdvs.dj.domain.constants.Stretching;
-import ar.com.fdvs.dj.domain.constants.VerticalAlign;
+import ar.com.fdvs.dj.domain.constants.VerticalImageAlign;
+import ar.com.fdvs.dj.domain.constants.VerticalTextAlign;
 
 /**
  * This test intends to show how to create multi line title and sub title
@@ -56,9 +58,10 @@ public class MultiLineTitleReportTest extends BaseDjReportTest {
 		 */
 		FastReportBuilder drb = new FastReportBuilder();
 		Style subtitleStyle = new Style("subtitle_style");
-		subtitleStyle.setStretchWithOverflow(true);
-		subtitleStyle.setStreching(Stretching.NO_STRETCH);
-		subtitleStyle.setVerticalAlign(VerticalAlign.TOP);
+		subtitleStyle.SetTextAdjust(TextAdjustEnum.STRETCH_HEIGHT);
+		subtitleStyle.setStretchType(StretchTypeEnum.NO_STRETCH);
+		subtitleStyle.setVerticalTextAlign(VerticalTextAlign.TOP);
+		subtitleStyle.setVerticalImageAlign(VerticalImageAlign.TOP);
 		
 		drb.addColumn("State", "state", String.class.getName(),30)
 			.addColumn("Branch", "branch", String.class.getName(),30)

--- a/src/test/java/ar/com/fdvs/dj/test/groups/labels/GroupLabelTest1b.java
+++ b/src/test/java/ar/com/fdvs/dj/test/groups/labels/GroupLabelTest1b.java
@@ -31,6 +31,8 @@ package ar.com.fdvs.dj.test.groups.labels;
 
 import java.awt.Color;
 
+import net.sf.jasperreports.engine.type.StretchTypeEnum;
+import net.sf.jasperreports.engine.type.TextAdjustEnum;
 import net.sf.jasperreports.view.JasperDesignViewer;
 import net.sf.jasperreports.view.JasperViewer;
 import ar.com.fdvs.dj.domain.AutoText;
@@ -46,10 +48,11 @@ import ar.com.fdvs.dj.domain.builders.StyleBuilder;
 import ar.com.fdvs.dj.domain.constants.Border;
 import ar.com.fdvs.dj.domain.constants.Font;
 import ar.com.fdvs.dj.domain.constants.GroupLayout;
-import ar.com.fdvs.dj.domain.constants.HorizontalAlign;
-import ar.com.fdvs.dj.domain.constants.Stretching;
+import ar.com.fdvs.dj.domain.constants.HorizontalImageAlign;
+import ar.com.fdvs.dj.domain.constants.HorizontalTextAlign;
 import ar.com.fdvs.dj.domain.constants.Transparency;
-import ar.com.fdvs.dj.domain.constants.VerticalAlign;
+import ar.com.fdvs.dj.domain.constants.VerticalImageAlign;
+import ar.com.fdvs.dj.domain.constants.VerticalTextAlign;
 import ar.com.fdvs.dj.domain.entities.DJGroup;
 import ar.com.fdvs.dj.domain.entities.columns.AbstractColumn;
 import ar.com.fdvs.dj.domain.entities.columns.PropertyColumn;
@@ -66,21 +69,27 @@ public class GroupLabelTest1b extends BaseDjReportTest {
 		headerStyle.setBorderBottom(Border.PEN_1_POINT());
 		headerStyle.setBackgroundColor(Color.gray);
 		headerStyle.setTextColor(Color.white);
-		headerStyle.setHorizontalAlign(HorizontalAlign.CENTER);
-		headerStyle.setVerticalAlign(VerticalAlign.MIDDLE);
+		headerStyle.setHorizontalTextAlign(HorizontalTextAlign.CENTER);
+		headerStyle.setHorizontalImageAlign(HorizontalImageAlign.CENTER);
+		headerStyle.setVerticalTextAlign(VerticalTextAlign.MIDDLE);
+		headerStyle.setVerticalImageAlign(VerticalImageAlign.MIDDLE);
+
 		headerStyle.setTransparency(Transparency.OPAQUE);
 
 		Style headerVariables = new Style();
 		headerVariables.setFont(Font.ARIAL_MEDIUM_BOLD);
 //		headerVariables.setBorder(Border.THIN());
-		headerVariables.setHorizontalAlign(HorizontalAlign.RIGHT);
-		headerVariables.setStreching(Stretching.NO_STRETCH);
-		headerVariables.setVerticalAlign(VerticalAlign.TOP);
+		headerVariables.setHorizontalTextAlign(HorizontalTextAlign.RIGHT);
+		headerVariables.setHorizontalImageAlign(HorizontalImageAlign.RIGHT);		
+		headerVariables.setStretchType(StretchTypeEnum.NO_STRETCH);
+		headerVariables.setVerticalTextAlign(VerticalTextAlign.TOP);
+		headerVariables.setVerticalImageAlign(VerticalImageAlign.TOP);
 
 		Style titleStyle = new Style();
 		titleStyle.setFont(new Font(18, Font._FONT_VERDANA, true));
 		Style importeStyle = new Style();
-		importeStyle.setHorizontalAlign(HorizontalAlign.RIGHT);
+		importeStyle.setHorizontalTextAlign(HorizontalTextAlign.RIGHT);
+		importeStyle.setHorizontalImageAlign(HorizontalImageAlign.RIGHT);
 		Style oddRowStyle = new Style();
 		oddRowStyle.setBorder(Border.NO_BORDER());
 		oddRowStyle.setBackgroundColor(Color.LIGHT_GRAY);
@@ -138,8 +147,10 @@ public class GroupLabelTest1b extends BaseDjReportTest {
 		GroupBuilder gb1 = new GroupBuilder();
 
 		Style glabelStyle = new StyleBuilder(false).setFont(Font.ARIAL_SMALL)
-			.setHorizontalAlign(HorizontalAlign.RIGHT).setBorderTop(Border.THIN())
-			.setStretchWithOverflow(false)
+			.setHorizontalTextAlign(HorizontalTextAlign.RIGHT)
+			.setHorizontalImageAlign(HorizontalImageAlign.RIGHT)
+			.setBorderTop(Border.THIN())
+			.setTextAdjust(TextAdjustEnum.CUT_TEXT)
 			.build();
 		
 		DJGroupLabel glabel1 = new DJGroupLabel("Total amount",glabelStyle);


### PR DESCRIPTION
@juanalvarezg this PR:

- Fixes #103 allowing users to set alignment without using deprecated code
- Updates min and max JasperReports to 6.11.0 and 6.20.0
- Deprecates `stretchwithoverflow` in favor of  `TextAdjust` options introduced in JasperReports 6.11.0
- Deprecates `Stretching` in favor of `StretchType`
- Removes use of deprecated `PlotOrientation` in favor of `PlotOrientationEnum`
- Updates version to 5.3.7-SNAPSHOT